### PR TITLE
Feat:support `\` to  path splitting and add a parameter --tsconfig

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,10 @@ const cli = cac('vue-dts-gen')
 cli
   .command('[...vue files]', 'Generate .d.ts for .vue files')
   .option('--outDir <dir>', 'Output directory')
-  .action(async (input, flags: { outDir?: string }) => {
+  .option('--tsconfig <dir>','specified tsconfig.json path')
+  .action(async (input, flags: { outDir?: string,tsconfig?:string }) => {
     const { build } = await import('./')
-    await build({ input, outDir: flags.outDir })
+    await build({ input, outDir: flags.outDir,tsconfig:flags.tsconfig })
   })
 
 cli.version(version)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ const cli = cac('vue-dts-gen')
 cli
   .command('[...vue files]', 'Generate .d.ts for .vue files')
   .option('--outDir <dir>', 'Output directory')
-  .option('--tsconfig <dir>','specified tsconfig.json path')
+  .option('--tsconfig <dir>','specified tsconfig.json with absolute path')
   .action(async (input, flags: { outDir?: string,tsconfig?:string }) => {
     const { build } = await import('./')
     await build({ input, outDir: flags.outDir,tsconfig:flags.tsconfig })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import path from 'path'
 import fs from 'fs'
-import { Project, SourceFile } from 'ts-morph'
+import { Project, SourceFile, ts } from 'ts-morph'
 import glob from 'fast-glob'
 
 export type Options = {
   input: string | string[]
   outDir?: string
+  tsconfig?:string
 }
 
 let vueCompiler: typeof import('@vue/compiler-sfc')
@@ -25,11 +26,30 @@ const getVueCompiler = () => {
   return vueCompiler
 }
 
-export async function build({ input, outDir }: Options) {
+export async function build({ input, outDir,tsconfig }: Options) {
   const vueCompiler = getVueCompiler()
-  const tsConfigFilePath = fs.existsSync('tsconfig.json')
-    ? 'tsconfig.json'
-    : undefined
+  if (Array.isArray(input)) {
+   input = input.map((v)=>{
+      v=v.split(path.sep).join('/');
+      return v;
+    })
+  }
+  else{
+   input = input.split(path.sep).join('/')
+  }
+  let tsConfigFilePath:string|undefined
+    if (tsconfig){
+      tsConfigFilePath = tsconfig
+      if (!fs.existsSync(tsConfigFilePath)) {
+        tsConfigFilePath = undefined
+      }
+     tsConfigFilePath ? console.log('Using tsconfig:',tsConfigFilePath):console.log('tsconfig don\'t exist');
+    }
+  else {
+    tsConfigFilePath = fs.existsSync('tsconfig.json')
+      ? 'tsconfig.json'
+      : undefined
+  }
   const project = new Project({
     compilerOptions: {
       allowJs: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs'
-import { Project, SourceFile, ts } from 'ts-morph'
+import { Project, SourceFile } from 'ts-morph'
 import glob from 'fast-glob'
 
 export type Options = {


### PR DESCRIPTION
1. support `\` to  path splitting for input
> Use Terminal in Windows ,such as `cmder`. Path completion will be  use `\`
2. add a parameter `--tsconfig` to accept a absolute path with file `tsconfig.json`
> if project use Monorepo to manage ,`tsconfig.json` is hard to find ,but We have to use it 
> So need a parameter to specify 