### PR TITLE
feat: ensure output dir exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export async function build({ input, outDir }: Options) {
     const emitOutput = sourceFile.getEmitOutput()
     for (const outputFile of emitOutput.getOutputFiles()) {
       const filepath = outputFile.getFilePath().replace('.vue.d.ts', '.d.ts')
+      await fs.promises.mkdir(path.dirname(filepath), { recursive: true })
       await fs.promises.writeFile(filepath, outputFile.getText(), 'utf8')
       console.log(`Emitted ${filepath}`)
     }


### PR DESCRIPTION
Ensure output dir exists when use `--outDir` parameter.